### PR TITLE
bump patch-level for ompl release, add missing pkg-config dependency

### DIFF
--- a/lunar/package.xml
+++ b/lunar/package.xml
@@ -17,6 +17,7 @@
   <build_depend>cmake</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>pkg-config</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>eigen</run_depend>

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -124,7 +124,7 @@ tracks:
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
     devel_branch: null
-    last_version: 1.3.0
+    last_version: 1.3.1
     name: upstream
     patches: lunar
     release_inc: '1'


### PR DESCRIPTION
Hopefully, this it not too late for the lunar release.

This PR doesn't add python bindings, but I believe enabling the python bindings is as simple as adding these build steps:
```
# install extra dependencies:
sudo apt-get -y install python-dev python-pip castxml
sudo -H pip install -vU pygccxml https://bitbucket.org/ompl/pyplusplus/get/1.8.0.tar.gz
# configure
cmake ... <default bloom args>
# build
make update_bindings all
```
I am not sure how this can be done with bloom. Installing dependencies via pip is probably frowned upon...

@130s, any thoughts?